### PR TITLE
Add Racher Desktop distribution and Data

### DIFF
--- a/list-wsl.ps1
+++ b/list-wsl.ps1
@@ -7,8 +7,10 @@ $wslDistributions = Get-ChildItem -Path "HKCU:\SOFTWARE\Microsoft\Windows\Curren
     if ($distribution["Name"] -eq "docker-desktop") { $distribution["Linux Distro"] = "Docker Desktop"; $distribution["State"] = "Installed"; $distribution["WSL"] = 2; $distribution["systemd"] = "Disabled"; $distribution["Default User"] = ""; $distribution["Distro Version"] = "" }
     if ($distribution["Name"] -eq "docker-desktop-data") { $distribution["Linux Distro"] = "Docker Desktop Data"; $distribution["State"] = "Installed"; $distribution["WSL"] = 2; $distribution["systemd"] = "Disabled"; $distribution["Default User"] = ""; $distribution["Distro Version"] = "" }
     if ($distribution["Name"] -eq "docker-desktop-runtime") { $distribution["Linux Distro"] = "Docker Desktop Runtime"; $distribution["State"] = "Installed"; $distribution["WSL"] = 2; $distribution["systemd"] = "Disabled"; $distribution["Default User"] = ""; $distribution["Distro Version"] = "" }
+    if ($distribution["Name"] -eq "rancher-desktop") { $distribution["Linux Distro"] = "Rancher Desktop WSL Distribution"; $distribution["State"] = "Installed"; $distribution["WSL"] = 2; $distribution["systemd"] = "Disabled"; $distribution["Default User"] = ""; $distribution["Distro Version"] = "" }
+    if ($distribution["Name"] -eq "rancher-desktop-data") { $distribution["Linux Distro"] = "Rancher Desktop Data"; $distribution["State"] = "Installed"; $distribution["WSL"] = 2; $distribution["systemd"] = "Disabled"; $distribution["Default User"] = ""; $distribution["Distro Version"] = "" }
 
-    if ($distribution["Name"] -ne "docker-desktop" -and $distribution["Name"] -ne "docker-desktop-data" -and $distribution["Name"] -ne "docker-desktop-runtime") {
+    if ($distribution["Name"] -ne "docker-desktop" -and $distribution["Name"] -ne "docker-desktop-data" -and $distribution["Name"] -ne "docker-desktop-runtime" -and $distribution["Name"] -ne "rancher-desktop" -and $distribution["Name"] -ne "rancher-desktop-data") {
         $osRelease = Invoke-Expression "wsl.exe -d $($distribution["Name"]) cat /etc/os-release"
         if ($osRelease) {
             $distribution["Linux Distro"] = ($osRelease | Where-Object { $_ -like "PRETTY_NAME=*" }).Split("=")[1].Replace('"', '')


### PR DESCRIPTION
Steps:

```bash
➜ .\list-wsl.ps1
InvalidOperation: C:\Users\oleksis\Powershell\wslinternals\list-wsl.ps1:15:13
Line |
  15 |              $distribution["Distro Version"] = ($osRelease | Where-Obj …
     |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | You cannot call a method on a null-valued expression.
id: unknown user 0
/bin/sh: cat: not found
/bin/sh: id: not found

Name                 Linux Distro                     Distro Version                Default User systemd  State     WSL
----                 ------------                     --------------                ------------ -------  -----     ---
rancher-desktop      Rancher Desktop WSL Distribution                                            Disabled Installed   2
openSUSE-Leap-15.4   openSUSE Leap 15.5 Alpha         15.5 Alpha                    oleksis      Disabled Installed   2
docker-desktop       Docker Desktop                                                              Disabled Installed   2
Ubuntu               Ubuntu 22.04.2 LTS               22.04.2 LTS (Jammy Jellyfish) oleksis      Enabled  Installed   2
Debian               Debian GNU/Linux 11 (bullseye)   11 (bullseye)                 oleksis      Enabled  Installed   2
docker-desktop-data  Docker Desktop Data                                                         Disabled Installed   2
rancher-desktop-data  
```

Debug:

```bash
➜ wsl -l -v
  NAME                    STATE           VERSION
* docker-desktop-data     Stopped         2
  rancher-desktop         Stopped         2
  openSUSE-Leap-15.4      Stopped         2
  docker-desktop          Stopped         2
  Ubuntu                  Stopped         2
  Debian                  Stopped         2
  rancher-desktop-data    Stopped         2

➜ $distribution = @{}
➜ $distribution["Name"] = "rancher-desktop"
➜ $osRelease = Invoke-Expression "wsl.exe -d $($distribution["Name"]) cat /etc/os-release"^C
➜ echo $($distribution["Name"])
rancher-desktop
➜ $osRelease = Invoke-Expression "wsl.exe -d $($distribution["Name"]) cat /etc/os-release"
➜ echo $osRelease
NAME="Rancher Desktop WSL Distro"
ID="rancher-desktop-wsl-distro"
PRETTY_NAME="Rancher Desktop WSL Distribution"
VERSION_ID="0.34"
BUILD_ID="ab938a2c3eca8236022b93f9846e447a2a3320d5"
HOME_URL="https://rancherdesktop.io/"
SUPPORT_URL="https://rancher-users.slack.com/channels/rancher-desktop"
BUG_REPORT_URL="https://github.com/rancher-sandbox/rancher-desktop-wsl-distro/issues/new"

➜ wsl -d Ubuntu
➜ cat /etc/os-release
PRETTY_NAME="Ubuntu 22.04.2 LTS"
NAME="Ubuntu"
VERSION_ID="22.04"
VERSION="22.04.2 LTS (Jammy Jellyfish)"
VERSION_CODENAME=jammy
ID=ubuntu
ID_LIKE=debian
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
UBUNTU_CODENAME=jammy
```

Fix with this PR

```bash
➜ .\list-wsl.ps1

Name                 Linux Distro                     Distro Version                Default User systemd  State
----                 ------------                     --------------                ------------ -------  -----    
rancher-desktop      Rancher Desktop WSL Distribution                                            Disabled Installed
openSUSE-Leap-15.4   openSUSE Leap 15.5 Alpha         15.5 Alpha                    oleksis      Disabled Installed
docker-desktop       Docker Desktop                                                              Disabled Installed
Ubuntu               Ubuntu 22.04.2 LTS               22.04.2 LTS (Jammy Jellyfish) oleksis      Enabled  Installed
Debian               Debian GNU/Linux 11 (bullseye)   11 (bullseye)                 oleksis      Enabled  Installed
docker-desktop-data  Docker Desktop Data                                                         Disabled Installed
rancher-desktop-data Rancher Desktop Data                                                        Disabled Installed
```